### PR TITLE
_full_scan generates incorrect paths

### DIFF
--- a/lib/Filesys/Notify/Simple.pm
+++ b/lib/Filesys/Notify/Simple.pm
@@ -155,6 +155,10 @@ sub _full_scan {
 
     my %map;
     for my $paths (@paths) {
+        unless (ref $paths) {
+            $paths = [$paths];
+        }
+
         for my $path (@{$paths}) {
             my $fp = eval { Cwd::realpath($path) } or next;
             File::Find::finddepth({


### PR DESCRIPTION
Hello miyagawa,

The `_full_scan` subroutine generates incorrect path names which includes the memory address to the path/array ref. These changes correct this. This also gives support for monitoring single files to change (e.g. you can specify a filepath, instead of only a directory path).

All tests still pass, but I did have an issue with a temporary test script I've been using. Whenever I'm monitor all is fine, but as soon as I change a file that's being watched the program crashes (error below). Probably something stupid on my part, but I've been starting myself blind on it.

_test.pl_

``` perl
#!/usr/bin/env perl
use strict;
use lib './lib';
use Filesys::Notify::Simple;
use YAML;
use Data::Dumper;
use v5.12;
use FindBin qw($Bin);

my @paths = [$Bin.'/lib', $Bin.'/t/x', $Bin.'/README'];
my $fs = Filesys::Notify::Simple->new(\@paths);
$fs->wait;
```

_output_
`christiaan@desktop-ubuntu:~/Documenten/Filesys-Notify-Simple$ perl test.pl 
Can't use string ("") as a subroutine ref while "strict refs" in use at lib/Filesys/Notify/Simple.pm line 126.`
