### PR TITLE
Support running tests under `HARNESS_OPTIONS=j10`. GH Issue #12.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Filesys::Notify::Simple
 
 {{$NEXT}}
+       - Fix GH#12, Tests should no longer fail under HARNESS_OPTIONS=j10
 
 0.11  2013-06-12 17:39:36 PDT
         - use Milla

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,8 @@ my %WriteMakefileArgs = (
   "PREREQ_PM" => {},
   "TEST_REQUIRES" => {
     "Test::More" => 0,
-    "Test::SharedFork" => 0
+    "Test::SharedFork" => 0,
+    "File::Temp"       => 0,
   },
   "VERSION" => "0.11",
   "test" => {

--- a/cpanfile
+++ b/cpanfile
@@ -3,4 +3,5 @@ requires 'perl', '5.008001';
 on test => sub {
     requires 'Test::More';
     requires 'Test::SharedFork';
+    requires 'File::Temp';
 };

--- a/t/move.t
+++ b/t/move.t
@@ -2,13 +2,18 @@ use strict;
 use Filesys::Notify::Simple;
 use Test::More;
 use Test::SharedFork;
+use File::Temp qw( tempdir );
+
 use FindBin;
 
 plan tests => 2;
 
-my $w = Filesys::Notify::Simple->new([ "lib", "t" ]);
-my $test_file = "$FindBin::Bin/x/move_create.data";
-my $test_file_to = "$FindBin::Bin/x/move_create.data.to";
+my $dir = tempdir( DIR => "$FindBin::Bin/x" );
+my $w = Filesys::Notify::Simple->new([ "lib", "$dir" ]);
+
+my $test_file = "$dir/move_create.data";
+my $test_file_to = "$dir/move_create.data.to";
+
 
 my $pid = fork;
 if ($pid == 0) {

--- a/t/rm_create.t
+++ b/t/rm_create.t
@@ -3,16 +3,20 @@ use Filesys::Notify::Simple;
 use Test::More;
 use Test::SharedFork;
 use FindBin;
+use File::Temp qw( tempdir );
+
+my $dir = tempdir( DIR => "$FindBin::Bin/x" );
+
 
 plan tests => 2;
 
-my $w = Filesys::Notify::Simple->new([ "lib", "t" ]);
+my $w = Filesys::Notify::Simple->new([ "lib", "$dir" ]);
 
 my $pid = fork;
 if ($pid == 0) {
     Test::SharedFork->child;
     sleep 3;
-    my $test_file = "$FindBin::Bin/x/rm_create.data";
+    my $test_file = "$dir/rm_create.data";
     open my $out, ">", $test_file;
     print $out "foo" . time;
     close $out;


### PR DESCRIPTION
Previously, all work was done in a scratch dir at

```
$DIST/t/x/
```

And each test was using a notifcation on

```
$DIST/lib/
$DIST/x/
```

So when each test added new files to scratch dir, all tests listening
for notificaton saw the event, and saw file creations they had not
anticipated.

This patch resolves that by using File::Temp to create a tempdir for
each test, and to only listen on that subdir

```
$DIST/lib/
$DIST/x/{TEMPDIRPREFIX}/
```
