### PR TITLE
Skip tests requiring fork() when no fork() is available

### DIFF
--- a/t/move.t
+++ b/t/move.t
@@ -1,10 +1,17 @@
 use strict;
+use Config;
 use Filesys::Notify::Simple;
 use Test::More;
 use Test::SharedFork;
 use File::Temp qw( tempdir );
 
 use FindBin;
+
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 plan tests => 2;
 

--- a/t/rm_create.t
+++ b/t/rm_create.t
@@ -1,4 +1,5 @@
 use strict;
+use Config;
 use Filesys::Notify::Simple;
 use Test::More;
 use Test::SharedFork;
@@ -7,6 +8,11 @@ use File::Temp qw( tempdir );
 
 my $dir = tempdir( DIR => "$FindBin::Bin/x" );
 
+plan skip_all => "fork not supported on this platform"
+  unless $Config::Config{d_fork} || $Config::Config{d_pseudofork} ||
+    (($^O eq 'MSWin32' || $^O eq 'NetWare') and
+     $Config::Config{useithreads} and
+     $Config::Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/);
 
 plan tests => 2;
 


### PR DESCRIPTION
If you build perl on Windows without -DPERL_IMPLICIT_SYS (which I do, in
order to enable -DPEL_MALLOC, which seems faster than using the system
malloc()) then you don't get the fork() emulation and several of
Filesys-Notify-Simple's tests fail.

This commit skips those tests in the same manner as various other CPAN
modules do in this case. This allows a normal "cpan install ..." of
Filesys-Notify-Simple or anything depending on it (e.g. Plack) to succeed
without having to "force" anything.
