### PR TITLE
Call Carp::croak when an error occurs in Linux::Inotify2::watch

### DIFF
--- a/lib/Filesys/Notify/Simple.pm
+++ b/lib/Filesys/Notify/Simple.pm
@@ -55,7 +55,8 @@ sub wait_inotify2 {
 
     my $fs = _full_scan(@path);
     for my $path (keys %$fs) {
-        $inotify->watch($path, &IN_MODIFY|&IN_CREATE|&IN_DELETE|&IN_DELETE_SELF|&IN_MOVE_SELF|&IN_MOVE);
+        $inotify->watch($path, &IN_MODIFY|&IN_CREATE|&IN_DELETE|&IN_DELETE_SELF|&IN_MOVE_SELF|&IN_MOVE)
+            or Carp::croak("watch failed: $!");
     }
 
     return sub {


### PR DESCRIPTION
Filesys::Notify::Simple::wait_inotify2 ignores errors of Linux::Inotify2::watch and waits file I/Os.
Therefore, it is unclear whether all of specified directories are watched correctly.
To clarify the problem, this p-r calls Carp::croak if Linux::Inotify2::watch is failed.