### PR TITLE
Ask for file events from Mac::FSEvents.

### DIFF
--- a/lib/Filesys/Notify/Simple.pm
+++ b/lib/Filesys/Notify/Simple.pm
@@ -76,7 +76,7 @@ sub wait_fsevents {
 
     my %events;
     for my $path (@path) {
-        my $fsevents = Mac::FSEvents->new({ path => $path, latency => 1 });
+        my $fsevents = Mac::FSEvents->new({ path => $path, latency => 1, file_events => 1 });
         my $fh = $fsevents->watch;
         $sel->add($fh);
         $events{fileno $fh} = $fsevents;


### PR DESCRIPTION
This is so individual files can be watched, not just directories.

(I discovered this because running `plackup --reload` on a Mac and then editing `app.psgi` does not cause the server to restart as it does on Linux.)