### PR TITLE
inconsistent behavior with missing files

### DIFF
--- a/lib/Filesys/Notify/Simple.pm
+++ b/lib/Filesys/Notify/Simple.pm
@@ -15,6 +15,8 @@ sub new {
         Carp::croak('Usage: Filesys::Notify::Simple->new([ $path1, $path2 ])');
     }
 
+    @$path = grep { -e $_ } @$path;
+
     my $self = bless { paths => $path }, $class;
     $self->init;
 


### PR DESCRIPTION
If you pass a missing file/path to FNS with the fallback polling method, it runs fine.
If you do that with Linux::Inotify2 installed, however, it raises an exception.

Since t/non_existent_path.t tests to make sure a missing file doesn't raise an exception, I'm guessing that's the behavior we want everywhere. 

Can we just ignore missing files everywhere? Or is there a better fix?